### PR TITLE
Update incorrect graphql type definition file in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     },
     "typeRoots": ["node_modules/@types", "src/@types"],
   },
-  "files": ["src/@types/graphql.d.ts"],
+  "files": ["src/graphql.d.ts"],
   "include": ["src/**/*"],
   "exclude": ["codegen.ts", "dist"]
 }


### PR DESCRIPTION
The starter code for this repo has the wrong path for the graphql.d.ts file inside of tsconfig.json which causes a typescript error to be thrown in the code editor. This updates the tsconfig.json file to point to the right file path.